### PR TITLE
fix typos

### DIFF
--- a/docs/src/DeflatedContinuation.md
+++ b/docs/src/DeflatedContinuation.md
@@ -49,12 +49,12 @@ return S
 The following piece of information is valuable in order to get the algorithm working in various conditions (see also [here](https://github.com/rveltz/BifurcationKit.jl/issues/33)) especially for small systems (e.g. dim<20):
 
 - `newton` is quite good and it is convenient to limit it otherwise it will be able to bypass the deflation. For example, you can use `maxIter = 10` in `NewtonPar`
-- try to limit the newton residual by using the argument `callbackN = BifurcationKit. cbMaxNorm(1e7)`. This will likely remove the occurence of `┌ Error: Same solution found for identical parameter value!!`
-- finally, you can try some agressive shift (here `0.01` in the deflation operator, like `DeflationOperator(2, dot, 0.01, [sol])` but use it wisely.
+- try to limit the newton residual by using the argument `callbackN = BifurcationKit. cbMaxNorm(1e7)`. This will likely remove the occurrence of `┌ Error: Same solution found for identical parameter value!!`
+- finally, you can try some aggressive shift (here `0.01` in the deflation operator, like `DeflationOperator(2, dot, 0.01, [sol])` but use it wisely.
 
 ## Basic example
 
-We show a quick and simple example of use. Note in particular that the algoritm is able to find the disconnected branch. The starting points are marked with crosses
+We show a quick and simple example of use. Note in particular that the algorithm is able to find the disconnected branch. The starting points are marked with crosses
 
 ```@example
 using BifurcationKit, LinearAlgebra, Setfield, SparseArrays, Plots

--- a/docs/src/ModulatedTW.md
+++ b/docs/src/ModulatedTW.md
@@ -3,7 +3,7 @@
 !!! warning ""
     This is work in progress
 
-A modulated travelling wave with period $T$ satifies $q(x,t+T) = q(x-s T,t)$. Equivalently, using a moving frame to freeze the wave $\xi=x-st$, it holds that $\tilde q(\xi,t+T) = \tilde q(\xi,t)$ where $\tilde q(\xi,t):=q(\xi+st,t)$. Hence, $\tilde q$ is a periodic solution to
+A modulated travelling wave with period $T$ satisfies $q(x,t+T) = q(x-s T,t)$. Equivalently, using a moving frame to freeze the wave $\xi=x-st$, it holds that $\tilde q(\xi,t+T) = \tilde q(\xi,t)$ where $\tilde q(\xi,t):=q(\xi+st,t)$. Hence, $\tilde q$ is a periodic solution to
 
 $$\partial_t\tilde q = -sT\cdot\tilde q+F(\tilde q,p).\tag{eqMWP}$$
 

--- a/docs/src/Predictors.md
+++ b/docs/src/Predictors.md
@@ -16,7 +16,7 @@ There are several couples predictor-tangent/corrector which can be used in **Bif
 
 ## 1. Natural, zeroth order predictor
 
-This is the dumbest predictor based on the formula $(x_1,p_1) = (x_0, p_0 + ds)$ with Newton corrector ; it fails at Turning points. This is set by the algorithm `Natural()` in [`continuation`](@ref). For matrix based jacobian, it is not faster than the pseudo-arclength predictor because the factorisation of the jacobian is catched. For Matrix-free methods, this predictor can be faster than the following ones until it hits a Turning point.
+This is the dumbest predictor based on the formula $(x_1,p_1) = (x_0, p_0 + ds)$ with Newton corrector ; it fails at Turning points. This is set by the algorithm `Natural()` in [`continuation`](@ref). For matrix based jacobian, it is not faster than the pseudo-arclength predictor because the factorisation of the jacobian is cached. For Matrix-free methods, this predictor can be faster than the following ones until it hits a Turning point.
 
 ## 2. First order predictor
 

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -71,7 +71,7 @@ The package does not yet allow to compute periodic orbits solutions of non-auton
 
 $$\frac{du}{dt}  = F(u, par, t).$$
 
-On certains cases, one can still go away with the following trick. Say one is interested (dummy example!) to study
+On certain cases, one can still go away with the following trick. Say one is interested (dummy example!) to study
 
 $$\dot u = cos(u) + cos(\omega \cdot t).$$
 

--- a/docs/src/periodicOrbitTrapeze.md
+++ b/docs/src/periodicOrbitTrapeze.md
@@ -78,7 +78,7 @@ Same as `: FullSparseInplace` above but the matrix `dG` is dense. It is also upd
 A matrix free linear solver is used for $\mathcal J$: note that a preconditioner is very likely required here because of the cyclic shape of $\mathcal J$ which affects negatively the convergence properties of iterative solvers. Note that $\mathcal J$ is never formed in this case.
 
 ### 5. BorderedLU
-For `:BorderedLU`, we take advantage of the bordered shape of the linear solver and use a LU decomposition to invert `dG` using a bordered linear solver. More precisely, the bordered structure of $\mathcal J$ is stored using the internal structure `POTrapJacobianBordered`. Then, $\mathcal J$ is inverted using the custom bordered linear solver `PeriodicOrbitTrapBLS` which is based on the bordering strategy (see [Bordered linear solvers (BLS)](@ref)). This particuliar solver is based on an explicit formula which only requires to invert $A_\gamma$: this is done by the linear solver `AγLinearSolver`. In a nutshell, we have:
+For `:BorderedLU`, we take advantage of the bordered shape of the linear solver and use a LU decomposition to invert `dG` using a bordered linear solver. More precisely, the bordered structure of $\mathcal J$ is stored using the internal structure `POTrapJacobianBordered`. Then, $\mathcal J$ is inverted using the custom bordered linear solver `PeriodicOrbitTrapBLS` which is based on the bordering strategy (see [Bordered linear solvers (BLS)](@ref)). This particular solver is based on an explicit formula which only requires to invert $A_\gamma$: this is done by the linear solver `AγLinearSolver`. In a nutshell, we have:
 
 ```
 PeriodicOrbitTrapBLS = BorderingBLS(solver = AγLinearSolver(), checkPrecision = false)

--- a/docs/src/plotting.md
+++ b/docs/src/plotting.md
@@ -47,7 +47,7 @@ The available arguments specific to our plotting methods are
 - `applytoX = identity` apply transformation `applytoX` to x-axis
 - `applytoY = identity` apply transformation `applytoY` to y-axis
 
-If you have severals branches `br1, br2`, you can plot them in the same figure by doing
+If you have several branches `br1, br2`, you can plot them in the same figure by doing
 
 ```julia
 plot(br1, br2)

--- a/docs/src/tutorials/Swift-Hohenberg1d.md
+++ b/docs/src/tutorials/Swift-Hohenberg1d.md
@@ -84,7 +84,7 @@ function cb(state; kwargs...)
 	fromNewton = get(kwargs, :fromNewton, false)
 	if ~fromNewton
 		# if the residual is too large or if the parameter jump
-		# is too big, abord continuation step
+		# is too big, abort continuation step
 		return norm(_x.u - state.x) < 20.5 && abs(_x.p - state.p) < 0.05
 	end
 	true

--- a/docs/src/tutorials/cgl1dwave.md
+++ b/docs/src/tutorials/cgl1dwave.md
@@ -22,7 +22,7 @@ const FD = ForwardDiff
 
 # supremum norm
 norminf(x) = norm(x, Inf)
-# pltting utilities
+# plotting utilities
 plotsol!(x, m, n; np = n, k...) = heatmap!(reshape(x[1:end-1],m,n)[1:np,:]; color =  :viridis, k...)
 contoursol!(x, m, n; np = n, k...) = contour!(reshape(x[1:end-1],m,n)[1:np,:]; color =  :viridis, k...)
 plotsol(x,m,n;k...) = (plot();plotsol!(x,m,n;k...))
@@ -193,7 +193,7 @@ end, bothside = true)
 plot(br, br_TW, legend = :bottomright, branchlabel =["","TW"])
 ```
 
-We note that the branch of travelling wave solutions has a Hopf bifurcation point at which point Modulated Travelling waves will emerge. This will be anlyzed in the future.
+We note that the branch of travelling wave solutions has a Hopf bifurcation point at which point Modulated Travelling waves will emerge. This will be analyzed in the future.
 
 
 ## References

--- a/docs/src/tutorials/mittelmann.md
+++ b/docs/src/tutorials/mittelmann.md
@@ -129,8 +129,8 @@ nothing #hide
 ```	 
 Note that we put the option `detectBifurcation = 3` to detect bifurcations precisely with a bisection method. Indeed, we need to locate these branch points precisely to be able to call automatic branch switching.
 
-## Branch of homogenous solutions
-At this stage, we note that the problem has a curve of homogenous (constant in space) solutions $u_h$ solving $N(\lambda, u_h)=0$. We shall compute this branch now.
+## Branch of homogeneous solutions
+At this stage, we note that the problem has a curve of homogeneous (constant in space) solutions $u_h$ solving $N(\lambda, u_h)=0$. We shall compute this branch now.
 
 Given that we will use these arguments for `continuation` many times, it is wise to collect them:
 
@@ -140,7 +140,7 @@ kwargsC = (verbosity = 0, plot = true, normC = norminf)
 nothing #hide
 ```
 
-We call `continuation` with the initial guess `sol0` which is homogenous, thereby generating homogenous solutions:
+We call `continuation` with the initial guess `sol0` which is homogeneous, thereby generating homogeneous solutions:
 
 ```@example MITT
 br = continuation(prob, PALC(), opts_br; kwargsC...)
@@ -179,7 +179,7 @@ scene = plot(br,br1,br2)
 
 ## Analysis at the 2d-branch points (manual)
 
-The second bifurcation point on the branch `br` of homogenous solutions has a 2d kernel. we provide two methods to deal with such case
+The second bifurcation point on the branch `br` of homogeneous solutions has a 2d kernel. we provide two methods to deal with such case
 - automatic local bifurcation diagram (see below)
 - branch switching with deflation (see next section)
 
@@ -245,7 +245,7 @@ We could use the solutions saved in `resp, resx` as initial guesses for a call t
 
 ## Branch switching with deflated newton (manual)
 
-At this stage, we know what happens at the 2d bifurcation point of the curve of homogenous solutions. We chose another method based on [Deflated problems](@ref). We want to find all nearby solutions of the problem close to this bifurcation point. This is readily done by trying several initial guesses in a brute force manner:
+At this stage, we know what happens at the 2d bifurcation point of the curve of homogeneous solutions. We chose another method based on [Deflated problems](@ref). We want to find all nearby solutions of the problem close to this bifurcation point. This is readily done by trying several initial guesses in a brute force manner:
 
 ```julia
 out = zeros(Nx*Ny)
@@ -256,7 +256,7 @@ deflationOp = DeflationOperator(2, 1.0, [zeros(Nx*Ny)])
 optdef = setproperties(opt_newton; tol = 1e-8, maxIter = 100)
 
 # eigen-elements close to the second bifurcation point on the branch
-# of homogenous solutions
+# of homogeneous solutions
 vp, ve, _, _= eigls(JFmit(out, @set par_mit.λ = br.specialpoint[2].param), 5)
 
 for ii=1:length(ve)

--- a/docs/src/tutorials/ode/tutorialCO.md
+++ b/docs/src/tutorials/ode/tutorialCO.md
@@ -1,4 +1,4 @@
-# CO-oxydation (codim 2)
+# CO oxidation (codim 2)
 
 ```@contents
 Pages = ["tutorialCO.md"]
@@ -6,7 +6,7 @@ Depth = 3
 ```
 
 In this tutorial, we study the Bykov–Yablonskii–Kim
-model of CO-oxydation (see [^Govaerts]). The goal of the tutorial is to show a simple example of how to perform codimension 2 bifurcation detection.
+model of CO oxidation (see [^Govaerts]). The goal of the tutorial is to show a simple example of how to perform codimension 2 bifurcation detection.
 
 $$\left\{\begin{array}{l}\dot{x}=2 q_{1} z^{2}-2 q_{5} x^{2}-q_{3} x y \\ \dot{y}=q_{2} z-q_{6} y-q_{3} x y \\ \dot{s}=q_{4} z-k q_{4} s\end{array}\right.\tag{E}$$
 

--- a/docs/src/tutorials/ode/tutorialsCodim2PO.md
+++ b/docs/src/tutorials/ode/tutorialsCodim2PO.md
@@ -7,7 +7,7 @@ Depth = 3
 
 > This example is found in the MatCont ecosystem.
 
-The following is a periodically forced predator-prey model studied in [^Kuznetsov] using shooting technics.
+The following is a periodically forced predator-prey model studied in [^Kuznetsov] using shooting techniques.
 
 $$\tag{E}\left\{\begin{aligned}
 \dot{x} & =r\left(1-\frac{x}{K}\right) x-\frac{a x y}{b_0(1+\varepsilon u)+x} \\

--- a/docs/src/tutorials/tutorialCarrier.md
+++ b/docs/src/tutorials/tutorialCarrier.md
@@ -7,7 +7,7 @@ In this example, we study the following singular perturbation problem:
 
 $$\epsilon^{2} y^{\prime \prime}+2\left(1-x^{2}\right) y+y^{2}=1, \quad y(-1)=y(1)=0\tag{E}.$$
 
-It is a remarkably difficult problem which presents many disconnected branches which are not amenable to the classical continuation methods. We thus use the recently developed *deflated continuation method* which builds upon the Deflated Newton (see [Deflated problems](@ref)) technics to find solutions which are different from a set of already known solutions.
+It is a remarkably difficult problem which presents many disconnected branches which are not amenable to the classical continuation methods. We thus use the recently developed *deflated continuation method* which builds upon the Deflated Newton (see [Deflated problems](@ref)) techniques to find solutions which are different from a set of already known solutions.
 
 We start with some import
 

--- a/docs/src/tutorials/tutorials3b.md
+++ b/docs/src/tutorials/tutorials3b.md
@@ -291,7 +291,7 @@ outpo_f = @time newton(poTrap, orbitguess_f, deflationOp, opt_po; normN = normin
 
 ## Floquet coefficients
 
-A basic method for computing Floquet cofficients based on the eigenvalues of the monodromy operator is available (see [`FloquetQaD`](@ref)). It is precise enough to locate bifurcations. Their computation is triggered like in the case of a regular call to `continuation`:
+A basic method for computing Floquet coefficients based on the eigenvalues of the monodromy operator is available (see [`FloquetQaD`](@ref)). It is precise enough to locate bifurcations. Their computation is triggered like in the case of a regular call to `continuation`:
 
 ```julia
 opt_po = @set opt_po.eigsolver = DefaultEig()

--- a/docs/src/tutorials/tutorialsCGL.md
+++ b/docs/src/tutorials/tutorialsCGL.md
@@ -470,7 +470,7 @@ Notice the small speed boost but the reduced allocations. At this stage, further
 
 ### Other linear formulation
 
-We could use another way to "invert" jacobian of the functional based on bordered technics. We try to use an ILU preconditioner on the cyclic matrix $J_c$ (see [Periodic orbits based on Trapezoidal rule](@ref)) which has a smaller memory footprint:
+We could use another way to "invert" jacobian of the functional based on bordered techniques. We try to use an ILU preconditioner on the cyclic matrix $J_c$ (see [Periodic orbits based on Trapezoidal rule](@ref)) which has a smaller memory footprint:
 
 ```julia
 Jpo2 = poTrap(Val(:JacCyclicSparse), orbitguess_f, @set par_cgl.r = r_hopf - 0.1)


### PR DESCRIPTION
Closes https://github.com/bifurcationkit/BifurcationKitDocs.jl/issues/3

This pull replaces `#4` which was closed.

I don't know if the change to tutorialsCodim2PO.md is problematic.

docs/src/DeflatedContinuation.md
docs/src/ModulatedTW.md
docs/src/Predictors.md
docs/src/faq.md
docs/src/periodicOrbitTrapeze.md
docs/src/plotting.md
docs/src/tutorials/Swift-Hohenberg1d.md
docs/src/tutorials/cgl1dwave.md
docs/src/tutorials/mittelmann.md
docs/src/tutorials/ode/tutorialCO.md
docs/src/tutorials/ode/tutorialsCodim2PO.md
docs/src/tutorials/tutorialCarrier.md
docs/src/tutorials/tutorials3b.md
docs/src/tutorials/tutorialsCGL.md